### PR TITLE
Load the Prettier resets after the `vue/recommended` ruleset.

### DIFF
--- a/eslint/eslint-vue.js
+++ b/eslint/eslint-vue.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: ['plugin:vue/recommended'],
+  extends: ['plugin:vue/recommended', 'plugin:prettier/recommended'],
   rules: {
     'vue/attributes-order': [
       'error',

--- a/tests/fixtures/vue-invalid.vue
+++ b/tests/fixtures/vue-invalid.vue
@@ -1,5 +1,5 @@
 <template>
-    <h1>{title}</h1>
+  <h1 class="foo-bar-incredible-long-classname" data-longattribute-id="extremely-long-string">{title}</h1>
 </template>
 
 <script>

--- a/tests/fixtures/vue-valid.vue
+++ b/tests/fixtures/vue-valid.vue
@@ -1,5 +1,10 @@
 <template>
-  <h1>{title}</h1>
+  <h1
+    class="foo-bar-incredible-long-classname"
+    data-longattribute-id="extremely-long-string"
+  >
+    {title}
+  </h1>
 </template>
 
 <script>


### PR DESCRIPTION
From the [ESLint docs](https://eslint.org/docs/user-guide/configuring/configuration-files#extending-configuration-files):
> The `extends` property value is either[...]:  an array of strings where each additional configuration extends the preceding configurations.

So whenever we integrate external rulesets, which might conflict with Prettier (e.g. [`vue/max-attributes-per-line`](https://eslint.vuejs.org/rules/max-attributes-per-line.html), we have to make sure to load the Prettier reset *after* those rulesets.

With this approach, both `eslint.base` and `eslint.vue` apply the resets, so it's kind of redundant. I don't know how and to what extent this is bad.

Successfully lints against https://github.com/dreipol/vue-ui/tree/next with `eslint-config-prettier` bumped to `8.1.0`.